### PR TITLE
doc: add SelectDataPage example to styling section

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,6 @@
+# Architektur
+
+## Styling
+
+Unser Frontend-Design orientiert sich an der [Matrix-Webseite](https://matrix.org/). Die Datei [SelectDataPage.tsx](frontend/src/pages/SelectDataPage.tsx) zeigt das gewünschte Card-Layout mit Schatten und Buttons besonders gut.
+


### PR DESCRIPTION
## Summary
- document styling guidance and reference SelectDataPage as example for card layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f11cfea688320ac36328217e3024f