### PR TITLE
Fix hosting path in architecture doc

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,7 @@
+# Architektur
+
+## Hosting-Plan
+
+- Pfad auf der Domain: `/bandsawcalc`
+- Vite-Konfiguration: `base: '/bandsawcalc/'`
+- Netlify-Redirect: Zielpfad `/bandsawcalc`


### PR DESCRIPTION
## Summary
- set domain path to `/bandsawcalc`
- update Vite base path and Netlify redirect

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f11cd4d488320841db3890ef95524